### PR TITLE
Add handling for TBA game times

### DIFF
--- a/nwslpy/nwslpy.py
+++ b/nwslpy/nwslpy.py
@@ -9,11 +9,11 @@ def _fix_types(df):
         if col in TYPES.keys():
             t = TYPES[col]
             if t == "datetime":
-                df[col] = pd.to_datetime(df[col])
+                df[col] = pd.to_datetime(df[col], errors="coerce")
             elif t == "date":
-                df[col] = pd.to_datetime(df[col]).dt.date
+                df[col] = pd.to_datetime(df[col], errors="coerce").dt.date
             elif t == "time":
-                df[col] = pd.to_datetime(df[col]).dt.time
+                df[col] = pd.to_datetime(df[col], errors="coerce").dt.time
 
     return df
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nwslpy"
-version = "0.0.0.6000"
+version = "0.0.0.7000"
 authors = [
   { name="Alison Gale", email="agale123.dev@gmail.com" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='nwslpy',
-      version='0.0.0.6000',
+      version='0.0.0.7000',
       description='Python wrapper around the nwslR library',
       packages=['nwslpy'],
       requires=[


### PR DESCRIPTION
The list of matches has one gametime as TBA which raises an error when trying to convert it to a Pandas datetime. This will swallow the error and leave a NaN.